### PR TITLE
feat: add failed scaling activity ignore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ module "tcp" {
 | <a name="input_extra_security_groups_backend"></a> [extra\_security\_groups\_backend](#input\_extra\_security\_groups\_backend) | A list of security group ids to assign to backend instances | `list(string)` | `[]` | no |
 | <a name="input_health_check_grace_period"></a> [health\_check\_grace\_period](#input\_health\_check\_grace\_period) | ASG will wait up to this number of seconds for instance to become healthy. | `number` | `900` | no |
 | <a name="input_health_check_type"></a> [health\_check\_type](#input\_health\_check\_type) | Type of healthcheck the ASG uses. Can be EC2 or ELB. | `string` | `"EC2"` | no |
+| <a name="input_ignore_failed_scaling_activities"></a> [ignore\_failed\_scaling\_activities](#input\_ignore\_failed\_scaling\_activities) | Whether to ignore failed Auto Scaling scaling activities while waiting for capacity. | `bool` | `false` | no |
 | <a name="input_instance_profile_permissions"></a> [instance\_profile\_permissions](#input\_instance\_profile\_permissions) | A JSON with a permissions policy document. The policy will be attached to the instance profile. | `string` | `null` | no |
 | <a name="input_instance_role_name"></a> [instance\_role\_name](#input\_instance\_role\_name) | If specified, the instance profile role will have this name. Otherwise, the role name will be generated. | `string` | `null` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instances type | `string` | `"t3.micro"` | no |

--- a/asg.tf
+++ b/asg.tf
@@ -1,16 +1,17 @@
 resource "aws_autoscaling_group" "tcp" {
-  name                      = var.asg_name
-  name_prefix               = var.asg_name == null ? aws_launch_template.tcp.name_prefix : null
-  min_size                  = local.asg_min_size
-  max_size                  = var.asg_max_size != null ? var.asg_max_size : length(var.backend_subnets) + 1
-  min_elb_capacity          = local.min_elb_capacity
-  vpc_zone_identifier       = var.backend_subnets
-  health_check_type         = var.health_check_type
-  wait_for_capacity_timeout = var.wait_for_capacity_timeout
-  max_instance_lifetime     = var.max_instance_lifetime_days * 24 * 3600
-  health_check_grace_period = var.health_check_grace_period
-  protect_from_scale_in     = var.protect_from_scale_in
-  target_group_arns         = var.target_group_type == "instance" && var.attach_target_group_to_asg ? [aws_lb_target_group.tcp.arn] : []
+  name                             = var.asg_name
+  name_prefix                      = var.asg_name == null ? aws_launch_template.tcp.name_prefix : null
+  min_size                         = local.asg_min_size
+  max_size                         = var.asg_max_size != null ? var.asg_max_size : length(var.backend_subnets) + 1
+  min_elb_capacity                 = local.min_elb_capacity
+  vpc_zone_identifier              = var.backend_subnets
+  health_check_type                = var.health_check_type
+  wait_for_capacity_timeout        = var.wait_for_capacity_timeout
+  ignore_failed_scaling_activities = var.ignore_failed_scaling_activities
+  max_instance_lifetime            = var.max_instance_lifetime_days * 24 * 3600
+  health_check_grace_period        = var.health_check_grace_period
+  protect_from_scale_in            = var.protect_from_scale_in
+  target_group_arns                = var.target_group_type == "instance" && var.attach_target_group_to_asg ? [aws_lb_target_group.tcp.arn] : []
   instance_refresh {
     strategy = "Rolling"
     preferences {

--- a/test_data/tcp-pod/main.tf
+++ b/test_data/tcp-pod/main.tf
@@ -18,15 +18,16 @@ module "lb" {
     aws     = aws
     aws.dns = aws
   }
-  service_name                 = "jumphost"
-  dns_a_records                = ["jumphost-tcp-pod"]
-  subnets                      = var.lb_subnet_ids
-  backend_subnets              = var.backend_subnet_ids
-  ami                          = data.aws_ami.ubuntu.id
-  nlb_listener_port            = 22
-  zone_id                      = data.aws_route53_zone.tcp.zone_id
-  key_pair_name                = aws_key_pair.test.key_name
-  userdata                     = module.jumphost-cloud-init.userdata
-  instance_profile_permissions = data.aws_iam_policy_document.permissions.json
-  instance_role_name           = var.instance_role_name
+  service_name                     = "jumphost"
+  dns_a_records                    = ["jumphost-tcp-pod"]
+  subnets                          = var.lb_subnet_ids
+  backend_subnets                  = var.backend_subnet_ids
+  ami                              = data.aws_ami.ubuntu.id
+  nlb_listener_port                = 22
+  zone_id                          = data.aws_route53_zone.tcp.zone_id
+  key_pair_name                    = aws_key_pair.test.key_name
+  userdata                         = module.jumphost-cloud-init.userdata
+  ignore_failed_scaling_activities = true
+  instance_profile_permissions     = data.aws_iam_policy_document.permissions.json
+  instance_role_name               = var.instance_role_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -166,6 +166,12 @@ variable "extra_security_groups_backend" {
   default     = []
 }
 
+variable "ignore_failed_scaling_activities" {
+  description = "Whether to ignore failed Auto Scaling scaling activities while waiting for capacity."
+  type        = bool
+  default     = false
+}
+
 variable "instance_role_name" {
   description = "If specified, the instance profile role will have this name. Otherwise, the role name will be generated."
   type        = string


### PR DESCRIPTION
## Summary
- add an `ignore_failed_scaling_activities` input
- pass the input to the managed Auto Scaling Group
- enable the option in the existing `tcp-pod` fixture so normal CI apply tests cover it
- document the new input in the README

## Why
Some workloads run on instance types or Availability Zones where capacity can fluctuate. AWS Auto Scaling may record a failed launch activity and then satisfy desired capacity with a later launch attempt. This option exposes the AWS provider setting that allows Terraform to keep waiting for capacity instead of failing immediately on the failed activity.

## Validation
- `terraform fmt -check -recursive`
- `git diff --check`

Full infrastructure tests were not run locally because they create AWS resources. The existing CI apply test fixture now enables this option so CI can validate it in the normal module test path.