### PR TITLE
fix: encrypt root EBS volume unconditionally

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -85,6 +85,7 @@ resource "aws_launch_template" "tcp" {
     ebs {
       volume_size           = var.root_volume_size
       delete_on_termination = true
+      encrypted             = true
     }
   }
   tag_specifications {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,8 @@ guaranteed on-demand base:
 | `userdata` | — | Cloud-init payload. |
 | `key_pair_name` | — | SSH key pair (or `null` for a generated one). |
 
+The root EBS volume is always encrypted with the AWS-managed `aws/ebs` key; there is no toggle to disable it.
+
 ## Security
 
 | Variable | Default | Description |


### PR DESCRIPTION
## Summary

The launch template in `asg.tf` attached the root EBS volume without setting `encrypted`, so in accounts where "EBS encryption by default" is off, instances got unencrypted root volumes.

This sets `encrypted = true` unconditionally in the `block_device_mappings` `ebs` block, using the AWS-managed `aws/ebs` key. Per the issue discussion, no `root_volume_encrypted` toggle is added — an opt-out would silently reintroduce the compliance gap. A note is added to `docs/configuration.md`.

Closes #31

Mirrors the same fix in website-pod: infrahouse/terraform-aws-website-pod#125.

## Behavioral note

Encryption applies at instance launch: existing instances keep their unencrypted volumes until the ASG instance refresh / roll replaces them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)